### PR TITLE
fix: remove page dependency from useEffect and searchParams

### DIFF
--- a/src/app/components/list/NameList.tsx
+++ b/src/app/components/list/NameList.tsx
@@ -125,25 +125,23 @@ const NameList = () => {
       </div>
       {names.length > 0 ? (
         <div className={"flex flex-col gap-4"}>
-          {names.length > 0 && (
-            <div className="grid grid-cols-1 gap-4 xs:grid-cols-2 sm:grid-cols-3 md:grid-cols-4">
-              {names.map(
-                (item, index) =>
-                  item.name && (
-                    <div
-                      key={index}
-                      className="flex aspect-square flex-col items-center justify-around overflow-hidden rounded bg-gray-100 p-4 text-center shadow"
-                    >
-                      <p></p>
-                      <p className="break-all text-black">{item.name}</p>
-                      <p className="break-all text-sm text-gray-600">
-                        {item.email.split("@")[0]}
-                      </p>
-                    </div>
-                  ),
-              )}
-            </div>
-          )}
+          <div className="grid grid-cols-1 gap-4 xs:grid-cols-2 sm:grid-cols-3 md:grid-cols-4">
+            {names.map(
+              (item, index) =>
+                item.name && (
+                  <div
+                    key={index}
+                    className="flex aspect-square flex-col items-center justify-around overflow-hidden rounded bg-gray-100 p-4 text-center shadow"
+                  >
+                    <p></p>
+                    <p className="break-all text-black">{item.name}</p>
+                    <p className="break-all text-sm text-gray-600">
+                      {item.email.split("@")[0]}
+                    </p>
+                  </div>
+                ),
+            )}
+          </div>
           {hasMore && (
             <Button onClick={handleGetMorePage} mode={"normal"}>
               더보기
@@ -159,14 +157,12 @@ const NameList = () => {
               className="h-auto w-full max-w-[200px]"
             />
           ) : (
-            <>
-              <div className="flex h-full flex-col text-center">
-                <h1 className={"mb-4 text-2xl"}>해당하는 데이터가 없어요!</h1>
-                <Button onClick={handleResetFilter} mode={"normal"}>
-                  돌아가기
-                </Button>
-              </div>
-            </>
+            <div className="flex h-full flex-col text-center">
+              <h1 className={"mb-4 text-2xl"}>해당하는 데이터가 없어요!</h1>
+              <Button onClick={handleResetFilter} mode={"normal"}>
+                돌아가기
+              </Button>
+            </div>
           )}
         </div>
       )}

--- a/src/app/components/list/NameList.tsx
+++ b/src/app/components/list/NameList.tsx
@@ -22,7 +22,6 @@ const NameList = () => {
     const params: Record<string, string> = {
       sortBy,
       sortOrder,
-      page: String(page),
     };
 
     if (searchValue) {
@@ -31,15 +30,12 @@ const NameList = () => {
     }
 
     return new URLSearchParams(params).toString();
-  }, [page, searchBy, searchValue, sortBy, sortOrder]);
+  }, [searchBy, searchValue, sortBy, sortOrder]);
 
-  const fetchNames = async () => {
+  const fetchNames = async (currentPage: number) => {
     setIsLoading(true);
-    setPage(1);
-    setHasMore(true);
-    setNames([]);
 
-    const res = await fetch(`/api/names?${searchParams}`, {
+    const res = await fetch(`/api/names?${searchParams}&page=${currentPage}`, {
       method: "GET",
     });
     const data = await res.json();
@@ -52,8 +48,16 @@ const NameList = () => {
   };
 
   useEffect(() => {
-    fetchNames();
+    setPage(1);
+    setNames([]);
+    setHasMore(true);
+    fetchNames(1);
   }, [searchParams]);
+
+  useEffect(() => {
+    if (page === 1) return;
+    fetchNames(page);
+  }, [page]);
 
   const handleResetFilter = () => {
     setSearchBy("name");
@@ -64,7 +68,8 @@ const NameList = () => {
   };
 
   const handleGetMorePage = () => {
-    setPage(page + 1);
+    // setPage(page + 1);
+    setPage((prev) => prev + 1);
   };
 
   const handleChangeSearchBy = (e: React.ChangeEvent<HTMLSelectElement>) => {


### PR DESCRIPTION
- page가 변할 때 searchParams도 변하면서 발생하는 버그 수정
- searchParams에서 page 제거
- fetchNames 함수에서 page를 searchParams와 별개로 쿼리 URL에 추가
- useEffect 훅을 분리하여 초기 로딩과 페이지 변경 시 데이터를 독립적으로 처리